### PR TITLE
Namespaced API for structured access to Convex functions

### DIFF
--- a/convex_dart_cli/lib/src/types.dart
+++ b/convex_dart_cli/lib/src/types.dart
@@ -177,7 +177,7 @@ import 'package:convex_dart/src/convex_dart_for_generated_code.dart'
     as internal;
 import 'package:http/http.dart' as \$http;
 import 'dart:convert' as \$convert;
-export 'api.dart';
+${context.apiIndex.isEmpty ? '' : "export 'api.dart';"}
 
 class ConvexClient {
   static Future<void> init() async {
@@ -218,6 +218,7 @@ import "package:convex_dart/src/convex_dart_for_generated_code.dart";
     if (context.apiIndex.isEmpty) {
       return;
     }
+
     final buffer = StringBuffer();
     buffer.writeln("""
 // ignore_for_file: type=lint, unused_import, unnecessary_question_mark, dead_code

--- a/convex_dart_cli/lib/src/types.dart
+++ b/convex_dart_cli/lib/src/types.dart
@@ -21,6 +21,8 @@ class ClientBuildContext {
   // ignore: library_private_types_in_public_api
   final Set<_LiteralsUnion> enums = {};
   final Set<String> tables = {};
+  // moduleKey (e.g., "tasks" or "users/admin") -> functions in that module
+  final Map<String, List<ApiFnMeta>> apiIndex = {};
   ClientBuildContext();
 }
 
@@ -84,6 +86,8 @@ class FunctionsSpec with FunctionsSpecMappable {
     _buildSchema(context);
     // Create the literals.dart file
     _buildLiterals(context);
+    // Create the api.dart file
+    _buildApi(context);
     // Format the code
     int formattedCount = 0;
     int formatFailedCount = 0;
@@ -173,6 +177,8 @@ import 'package:convex_dart/src/convex_dart_for_generated_code.dart'
     as internal;
 import 'package:http/http.dart' as \$http;
 import 'dart:convert' as \$convert;
+export 'api.dart';
+
 class ConvexClient {
   static Future<void> init() async {
     await internal.InternalConvexClient.init(
@@ -207,6 +213,130 @@ import "package:convex_dart/src/convex_dart_for_generated_code.dart";
     }
     context.outputs[path.join("literals.dart")] = literalsBuffer.toString();
   }
+
+  void _buildApi(ClientBuildContext context) {
+    if (context.apiIndex.isEmpty) {
+      return;
+    }
+    final buffer = StringBuffer();
+    buffer.writeln("""
+// ignore_for_file: type=lint, unused_import, unnecessary_question_mark, dead_code
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter, invalid_use_of_internal_member
+""");
+    // Stable import aliasing
+    final uniqueImports =
+        context.apiIndex.values
+            .expand((metas) => metas)
+            .map((m) => m.importPath)
+            .toSet()
+            .toList()
+          ..sort();
+    final importAlias = <String, String>{};
+    for (var i = 0; i < uniqueImports.length; i++) {
+      importAlias[uniqueImports[i]] = "_m${i + 1}";
+    }
+    for (final imp in uniqueImports) {
+      final alias = importAlias[imp]!;
+      buffer.writeln("import '$imp' as $alias;");
+    }
+    buffer.writeln();
+
+    // Build namespace tree
+    final root = _ApiNode();
+    for (final entry in context.apiIndex.entries) {
+      final segments = entry.key.isEmpty ? <String>[] : entry.key.split("/");
+      var current = root;
+      for (final seg in segments) {
+        current = current.children.putIfAbsent(seg, () => _ApiNode());
+      }
+      current.functions.addAll(entry.value);
+    }
+
+    // Emit classes
+    void writeClass(_ApiNode node, List<String> pathSegments) {
+      final className = _className(pathSegments);
+
+      buffer.writeln("class $className {");
+      buffer.writeln("  const $className();");
+
+      final children = node.children.keys.toList()..sort();
+      for (final seg in children) {
+        final childClass = _className([...pathSegments, seg]);
+        final propName = ReCase(seg).camelCase;
+        buffer.writeln("  $childClass get $propName => const $childClass();");
+      }
+
+      if (children.isNotEmpty && node.functions.isNotEmpty) {
+        buffer.writeln();
+      }
+
+      node.functions.sort((a, b) => a.functionName.compareTo(b.functionName));
+      for (var i = 0; i < node.functions.length; i++) {
+        final f = node.functions[i];
+        final alias = importAlias[f.importPath]!;
+        final returnsType = "$alias.${f.returnsTypeName}";
+        final params = f.argsTypeName != null
+            ? "$alias.${f.argsTypeName!} args"
+            : "";
+        final callArgs = f.argsTypeName != null ? "args" : "";
+
+        buffer.writeln(
+          "  Future<$returnsType> ${f.functionName}($params) => $alias.${f.functionName}($callArgs);",
+        );
+
+        if (f.functionType == "Query") {
+          buffer.writeln(
+            "  Stream<$returnsType> ${f.functionName}Stream($params) => $alias.${f.functionName}Stream($callArgs);",
+          );
+        }
+
+        if (i < node.functions.length - 1) {
+          buffer.writeln();
+        }
+      }
+
+      buffer.writeln("}");
+      buffer.writeln();
+
+      for (final seg in children) {
+        writeClass(node.children[seg]!, [...pathSegments, seg]);
+      }
+    }
+
+    writeClass(root, const []);
+    buffer.writeln("const api = ${_className(const [])}();");
+    context.outputs[path.join("api.dart")] = buffer.toString();
+  }
+
+  String _className(List<String> pathSegments) {
+    var name = "ConvexApi";
+    for (final segment in pathSegments) {
+      name += ReCase(segment).pascalCase;
+    }
+    return stringToDart(name);
+  }
+}
+
+class _ApiNode {
+  final Map<String, _ApiNode> children = {};
+  final List<ApiFnMeta> functions = [];
+}
+
+class ApiFnMeta {
+  final String importPath; // e.g., functions/tasks/createTask.dart
+  final String functionName; // e.g., createTask
+  final String functionType; // Query | Mutation | Action
+  final String? argsTypeName; // nullable for JsAny
+  final String returnsTypeName;
+
+  ApiFnMeta({
+    required this.importPath,
+    required this.functionName,
+    required this.functionType,
+    required this.argsTypeName,
+    required this.returnsTypeName,
+  });
 }
 
 @MappableEnum(mode: ValuesMode.named)
@@ -485,6 +615,19 @@ $returnsTypeName $deserializeMethodName(Value map) {
   return $deserializeCode;
 }
 """);
+    // Register this function for API namespace generation
+    final importPath = path.posix.joinAll(["functions", ...pathParts]);
+
+    final meta = ApiFnMeta(
+      importPath: importPath,
+      functionName: functionName,
+      functionType: functionType,
+      argsTypeName: argsTypeName,
+      returnsTypeName: returnsTypeName,
+    );
+
+    final moduleKey = pathParts.take(pathParts.length - 1).join("/");
+    context.clientContext.apiIndex.putIfAbsent(moduleKey, () => []).add(meta);
   }
 }
 


### PR DESCRIPTION
A revised version of [this pr](https://github.com/dickermoshe/convex-dart/pull/7). 

Once again I did use AI, but this time more for guidance. All of the code has been written / revised / reviewed by me. Compared to my earlier PR, this version sticks much closer to the generator’s existing flow:

- Each `FunctionSpec.build` call now puts its metadata into a little map on `ClientBuildContext`, so there’s no second traversal or duplicate visitor.
- After the usual schema/literal steps it writes a single `api.dart`, using that index to build the namespaces and `api` constant.
- The generated `client.dart` re-exports `api.dart`, so importing `client.dart` matches what your README shows.

All told, the diff is smaller now and follows the pattern you described in the review.
You might also want to update the README to reflect this new feature. I could also do that if you like.

I did some testing with this, and it seems to work fine. 
This is how the generated `api.dart` looks for my test app:
```dart
// ignore_for_file: type=lint, unused_import, unnecessary_question_mark, dead_code
// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter, invalid_use_of_internal_member

import 'functions/user_utils/ping.dart' as _m1;
import 'functions/user_utils/pingUser.dart' as _m2;
import 'functions/videos/list/forMe.dart' as _m3;

class ConvexApi {
  const ConvexApi();
  ConvexApiUserUtils get userUtils => const ConvexApiUserUtils();
  ConvexApiVideos get videos => const ConvexApiVideos();
}

class ConvexApiUserUtils {
  const ConvexApiUserUtils();
  Future<_m1.PingResponse> ping() => _m1.ping();
  Stream<_m1.PingResponse> pingStream() => _m1.pingStream();

  Future<_m2.PingUserResponse> pingUser() => _m2.pingUser();
  Stream<_m2.PingUserResponse> pingUserStream() => _m2.pingUserStream();
}

class ConvexApiVideos {
  const ConvexApiVideos();
  ConvexApiVideosList get list => const ConvexApiVideosList();
}

class ConvexApiVideosList {
  const ConvexApiVideosList();
  Future<_m3.ForMeResponse> forMe() => _m3.forMe();
  Stream<_m3.ForMeResponse> forMeStream() => _m3.forMeStream();
}

const api = ConvexApi();
```

You can now write a query like `api.videos.list.forMe()`, or still just use the `forMe()` directly if you like.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated clients now include a structured, type-safe API namespace that organizes functions by module for easier discovery.
  * The client export surface now exposes the generated API surface, making a top-level API instance and module-based access available to consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->